### PR TITLE
Remove TOPOS/topos-subnet page

### DIFF
--- a/docs/learn/topos-ledger.md
+++ b/docs/learn/topos-ledger.md
@@ -1,9 +1,0 @@
----
-sidebar_position: 3
----
-
-# TOPOS Subnet
-
-## Staking
-
-## Validators


### PR DESCRIPTION
Information is not viable as of today so we'd rather remove the page for now.