### PR TITLE
fix: show actual last author

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v2
         with:
           node-version: 18.x


### PR DESCRIPTION
# Description

#50 re-introduced the Docusaurus last edition time and author at the bottom of each page, but the information isn't right.

[This issue comment](https://github.com/facebook/docusaurus/issues/2798#issuecomment-636602951) explain that on Github Action only the latest commit is fetched so during the build only that piece of history is available to fill last time and author information. The solution, as described, is to request the action to get the whole history.

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
